### PR TITLE
fix verilator compatability

### DIFF
--- a/bench/verilator/tb.cpp
+++ b/bench/verilator/tb.cpp
@@ -86,7 +86,7 @@ int main(int argc, char **argv, char **env)
 
 	Vorpsoc_top* top = new Vorpsoc_top;
 	VerilatorTbUtils* tbUtils =
-		new VerilatorTbUtils(top->orpsoc_top->wb_bfm_memory0->ram0->mem);
+		new VerilatorTbUtils(top->orpsoc_top->wb_bfm_memory0->ram0->mem.data());
 
 	parse_args(argc, argv, tbUtils);
 


### PR DESCRIPTION
fixes the following error, most likely caused by a more recent Verilator update which introduced the VlUnpacked type: 

```
src/mor1kx-generic_1.1/bench/verilator/tb.cpp: In function ‘int main(int, char**, char**)’:
src/mor1kx-generic_1.1/bench/verilator/tb.cpp:89:80: error: no matching function for call to ‘VerilatorTbUtils::VerilatorTbUtils(VlUnpacked<unsigned int, 8388608>&)’
   89 |                 new VerilatorTbUtils(top->orpsoc_top->wb_bfm_memory0->ram0->mem);
      |                                                                                ^
In file included from src/mor1kx-generic_1.1/bench/verilator/tb.cpp:17:
src/verilator_tb_utils_1.0/verilator_tb_utils.h:13:3: note: candidate: ‘VerilatorTbUtils::VerilatorTbUtils(uint32_t*)’
   13 |   VerilatorTbUtils(uint32_t *mem);
      |   ^~~~~~~~~~~~~~~~
src/verilator_tb_utils_1.0/verilator_tb_utils.h:13:30: note:   no known conversion for argument 1 from ‘VlUnpacked<unsigned int, 8388608>’ to ‘uint32_t*’ {aka ‘unsigned int*’}
   13 |   VerilatorTbUtils(uint32_t *mem);
      |                    ~~~~~~~~~~^~~
src/verilator_tb_utils_1.0/verilator_tb_utils.h:11:7: note: candidate: ‘constexpr VerilatorTbUtils::VerilatorTbUtils(const VerilatorTbUtils&)’
   11 | class VerilatorTbUtils {
      |       ^~~~~~~~~~~~~~~~
src/verilator_tb_utils_1.0/verilator_tb_utils.h:11:7: note:   no known conversion for argument 1 from ‘VlUnpacked<unsigned int, 8388608>’ to ‘const VerilatorTbUtils&’
make[1]: *** [Vorpsoc_top.mk:76: tb.o] Error 1
make: *** [Makefile:13: Vorpsoc_top] Error 2

ERROR: Failed to build ::mor1kx-generic:1.1 : '['make']' exited with an error: 2
```